### PR TITLE
ensure correct binary is used and delete error

### DIFF
--- a/genesis-validators.md
+++ b/genesis-validators.md
@@ -374,7 +374,7 @@ your `.profile` so it is automatically set in every session.
 echo "# Setup Cosmovisor" >> ~/.profile
 echo "export DAEMON_NAME=osmosisd" >> ~/.profile
 echo "export DAEMON_HOME=$HOME/.osmosisd" >> ~/.profile
-echo 'export PATH="$DAEMON_HOME/cosmovisor:$PATH"' >> ~/.profile
+echo 'export PATH="$DAEMON_HOME/cosmovisor/current/bin:$PATH"' >> ~/.profile
 source ~/.profile
 ```
 

--- a/genesis-validators.md
+++ b/genesis-validators.md
@@ -374,7 +374,7 @@ your `.profile` so it is automatically set in every session.
 echo "# Setup Cosmovisor" >> ~/.profile
 echo "export DAEMON_NAME=osmosisd" >> ~/.profile
 echo "export DAEMON_HOME=$HOME/.osmosisd" >> ~/.profile
-echo 'export PATH="DAEMON_HOME/cosmovisor:$PATH"' >> ~/.profile
+echo 'export PATH="$DAEMON_HOME/cosmovisor:$PATH"' >> ~/.profile
 source ~/.profile
 ```
 

--- a/genesis-validators.md
+++ b/genesis-validators.md
@@ -374,15 +374,14 @@ your `.profile` so it is automatically set in every session.
 echo "# Setup Cosmovisor" >> ~/.profile
 echo "export DAEMON_NAME=osmosisd" >> ~/.profile
 echo "export DAEMON_HOME=$HOME/.osmosisd" >> ~/.profile
+echo 'export PATH="DAEMON_HOME/cosmovisor:$PATH"' >> ~/.profile
 source ~/.profile
 ```
 
-Finally, you should copy the osmosisd binary into the cosmovisor/genesis folder.
+Finally, you should move the osmosisd binary into the cosmovisor/genesis folder.
 ```
-cp $GOPATH/bin/osmosisd ~/.osmosisd/cosmovisor/genesis/bin
+mv $GOPATH/bin/osmosisd ~/.osmosisd/cosmovisor/genesis/bin
 ```
-
-This will create a new `.osmosisd` folder in your HOME directory.
 
 ### Download Genesis File
 


### PR DESCRIPTION
As learned during the last Regen Network testnet: it makes sense for the command line and cosmovisor to use the same binary for `osmosisd`. This means that the binary should be moved, not copied, to the cosmovisor directory, and the cosmovisor directory should be added to the PATH. If you don't do it this way, then you risk having two different binaries on the system, and those binaries eventually being different versions (after network upgrades), and weird things happening.

Also, deleted an extraneous line about adding a new `.osmosisd` directory -- that's from the `init` section.