### PR TITLE
update example systemd unit with unlimited nofile

### DIFF
--- a/genesis-validators.md
+++ b/genesis-validators.md
@@ -440,7 +440,7 @@ User=$USER
 ExecStart=$(which cosmovisor) start
 Restart=always
 RestartSec=3
-LimitNOFILE=4096
+LimitNOFILE=infinity
 
 Environment="DAEMON_HOME=$HOME/.osmosisd"
 Environment="DAEMON_NAME=osmosisd"


### PR DESCRIPTION
Many validators are dropping off the network during epochs, it is probable that systems with slower drives cannot write files fast enough to avoid 4096 open file handles. Because network connections count against the `nofile` ulimit, it is causing peers to drop.